### PR TITLE
fixes issues using rdflib 4.1.x imports - quick and dirty

### DIFF
--- a/plugins/surf.rdflib/setup.py
+++ b/plugins/surf.rdflib/setup.py
@@ -74,7 +74,7 @@ setup(
     packages            = ['surf_rdflib'],
     install_requires    = [
         'surf>=1.1.5',
-        'rdfextras',
+        #'rdfextras==0.4',
         'pyparsing',
         'rdflib>=3.2.1'],
     test_suite          = 'surf_rdflib.test',

--- a/plugins/surf.rdflib/surf_rdflib/__init__.py
+++ b/plugins/surf.rdflib/surf_rdflib/__init__.py
@@ -37,8 +37,8 @@ __author__ = 'Cosmin Basca'
 
 import rdflib
 
-if rdflib.__version__.startswith("3."):
-    rdflib.plugin.register('sparql', rdflib.query.Processor,
-                           'rdfextras.sparql.processor', 'Processor')
-    rdflib.plugin.register('sparql', rdflib.query.Result,
-                           'rdfextras.sparql.query', 'SPARQLQueryResult')
+#if rdflib.__version__.startswith("3."):
+#    rdflib.plugin.register('sparql', rdflib.query.Processor,
+#                           'rdfextras.sparql.processor', 'Processor')
+#    rdflib.plugin.register('sparql', rdflib.query.Result,
+#                           'rdfextras.sparql.query', 'SPARQLQueryResult')

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ __author__ = 'Cosmin Basca'
 
 from ez_setup import use_setuptools
 use_setuptools()
-from setuptools import setup
+from setuptools import setup, find_packages
 from sys import version_info
 
 def is_python(major=2, minor=5):
@@ -58,7 +58,8 @@ setup(
       url               = 'http://code.google.com/p/surfrdf/',
       download_url      = 'http://pypi.python.org/pypi/SuRF/',
       platforms         = ['any'],
-      packages          = ['surf'],
+      #packages          = ['surf'],
+      packages          = find_packages(exclude=['surf.test']),
       requires          = ['simplejson'] if is_python(2,5) else [],
       install_requires  = [
                               'rdflib>=3.2.1',

--- a/surf/rdf.py
+++ b/surf/rdf.py
@@ -60,5 +60,15 @@ if rdflib.__version__.startswith("2.5") or rdflib.__version__.startswith("3."):
     from rdflib.namespace import RDF, RDFS
     from rdflib.term import URIRef
 
+# 4.0 style imports
+if rdflib.__version__.startswith("4.1") or rdflib.__version__.startswith("3."):
+    from rdflib.term import BNode
+    from rdflib.graph import Graph, ConjunctiveGraph
+    from rdflib.term import Literal
+    from rdflib.namespace import ClosedNamespace, Namespace
+    from rdflib.namespace import RDF, RDFS
+    from rdflib.term import URIRef
+
+
 __exports__ = [BNode, ClosedNamespace, ConjunctiveGraph, Graph, Literal,
                Namespace, RDF, RDFS, URIRef]


### PR DESCRIPTION
the fix is hacky etc: added rdflib.__version__.startswith("4.1")
removes dependecies on rdfextras which are now included in rdflib, but i dont verify that SPARQL processors work. This fix should allow use of examples/rdflib_example.py