### PR TITLE
Added default_graph for writing to e.g. Virtuoso

### DIFF
--- a/surf/plugin/sparql_protocol/writer.py
+++ b/surf/plugin/sparql_protocol/writer.py
@@ -143,6 +143,10 @@ class WriterPlugin(RDFWriter):
 
         self._sparql_wrapper.setMethod("POST")
 
+        default_graph = kwargs.get('default_graph',None)
+        if default_graph:
+            self._sparql_wrapper.addDefaultGraph(default_graph)
+
     @property
     def endpoint(self):
         return self._endpoint


### PR DESCRIPTION
Currently Virtuoso returns a 400 Bad Request since it's missing the default graph. There seems to be no sign of usage of the `default_graph` attribute, which is needed for triple stores like Virtuoso. This PR enables SuRF to write to Openlink Virtuoso (07.20.3217).

Jena Fuseki seems to be indifferent about the change.
I have no clue about how other triples stores react to the new code.

This PR is fixing #15.